### PR TITLE
🐛 fix: 팔로잉 버튼 오류 수정 #131

### DIFF
--- a/src/components/profile/FollowItems.jsx
+++ b/src/components/profile/FollowItems.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FollowLiStyle } from '../../styles/FollowStyled';
 import { useRecoilValue } from 'recoil';
@@ -51,19 +51,20 @@ export default function FollowItems({ item }) {
             <p className="user-info">{item.intro}</p>
           </div>
         </button>
-        {item.accountname !== loginAccount && item.isfollow ? (
-          <BtnUnFollowing
-            item={item}
-            handleFollow={handleFollow}
-            handleUnFollow={handleUnFollow}
-          />
-        ) : (
-          <BtnFollowing
-            item={item}
-            handleFollow={handleFollow}
-            handleUnFollow={handleUnFollow}
-          />
-        )}
+        {item.accountname !== loginAccount &&
+          (item.isfollow ? (
+            <BtnUnFollowing
+              item={item}
+              handleFollow={handleFollow}
+              handleUnFollow={handleUnFollow}
+            />
+          ) : (
+            <BtnFollowing
+              item={item}
+              handleFollow={handleFollow}
+              handleUnFollow={handleUnFollow}
+            />
+          ))}
       </FollowLiStyle>
     </>
   );


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [x] 버그 수정 : 팔로잉 버튼 오류 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 자신의 계정은 다른 사람의 팔로잉 및 팔로워 목록에 보여도 팔로잉 버튼이 생기지 않아야 함. 그러나 생기는 이슈 발생.

### 작업 내역

- `src > components > profile > FollowItems.jsx` 파일 내에서 해당 유저와 로그인 유저의 accountname을 비교하는 코드를 확인. 이를 비교하여 동일하지 않을 때만 버튼이 나오도록 수정.

### 작업 후 기대 동작(스크린샷)

![image](https://github.com/FRONTENDSCHOOL7/final-19-Talkhoogam/assets/126058047/3cfbef8c-b048-4205-84e4-2b5bbb46898b)

### PR 특이 사항

- 특이 사항

### Issue Number 

close: #131 

### 어떤 부분에 리뷰어가 집중하면 좋을까요?


<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
